### PR TITLE
fix: use shell everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HELM_HOME ?= $(helm home)
+HELM_HOME ?= $(shell helm home)
 HAS_GLIDE := $(shell command -v glide;)
 
 .PHONY: install


### PR DESCRIPTION
`shell` is required to correctly populate `$HELM_HOME`.