### PR TITLE
Use /usr/bin/env bash in shebang line

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Combination of the Glide and Helm scripts, with my own tweaks.
 


### PR DESCRIPTION
This makes the script work in some less-common environments (e.g. NixOS) where `/bin/bash` does not exist but bash is still in `$PATH`