### PR TITLE
Fix /dev/null typo in install-binary script

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -11,7 +11,7 @@ PROJECT_GH="technosophos/$PROJECT_NAME"
 # available. This is the case when using MSYS2 or Cygwin
 # on Windows where helm returns a Windows path but we
 # need a Unix path
-if type cygpath > /dev/nul; then
+if type cygpath > /dev/null; then
   HELM_PLUGIN_PATH=$(cygpath -u $HELM_PLUGIN_PATH)
 fi
 


### PR DESCRIPTION
This is causing an error on install on linux machines:

```
/install-binary.sh: line 14: /dev/nul: Operation not permitted
```