### PR TITLE
Support aliased and disabled dependencies.

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,10 @@ func run(cmd *cobra.Command, args []string) error {
 
 	config := &chart.Config{Raw: string(vv), Values: map[string]*chart.Value{}}
 
+	if err = chartutil.ProcessRequirementsEnabled(c, config); err != nil {
+		return err
+	}
+
 	if flagVerbose {
 		fmt.Println("---\n# merged values")
 		fmt.Println(string(vv))


### PR DESCRIPTION
I started using the [alias feature](https://docs.helm.sh/developing_charts/#alias-field-in-requirements-yaml) that was shipped in Helm 2.5 (which is awesome by the way).   To save time testing refactors in a chart, I usually run a `helm install --debug --dry-run` and diff the manifests before and after.   Because [ordering is not guaranteed](https://github.com/kubernetes/helm/issues/1696), the diff becomes unwieldy as the number of manifests grows, so I have used this plugin instead.  This PR makes the alias work so I can smoke test my own refactors when using that feature.  Admittedly I should also try to fix the "issue" in helm, but this was much easier 😄 

This change should also fix #15.  I tested that locally as well and the disabled chart doesn't appear in the output when it's condition is set.  Of course I wouldn't mind having someone experiencing that try it for themselves.