### PR TITLE
Fix /dev/nul -> dev/null in install-binary.sh

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -11,7 +11,7 @@ PROJECT_GH="technosophos/$PROJECT_NAME"
 # available. This is the case when using MSYS2 or Cygwin
 # on Windows where helm returns a Windows path but we
 # need a Unix path
-if type cygpath > /dev/nul; then
+if type cygpath > /dev/null; then
   HELM_PLUGIN_PATH=$(cygpath -u $HELM_PLUGIN_PATH)
 fi
 


### PR DESCRIPTION
 I noticed a typo in install-binary.sh when  doing `helm plugin install https://github.com/technosophos/helm-template --version 2.5.1+2` after having removed and then about to reinstall:

```
helm plugin install https://github.com/technosophos/helm-template --version 2.5.1+2
/Users/rfay/.helm/plugins/helm-template/install-binary.sh: line 14: /dev/nul: Operation not permitted
```

Not trying to solve the underlying problem that the script should have stopped with such an error. For next time!