### PR TITLE
Add --kube-version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ $ helm template [flags] CHART
 ### Flags:
 
 ```
-      --notes               show the computed NOTES.txt file as well.
-      --set string          set values on the command line. See 'helm install -h'
-  -f, --values valueFiles   specify one or more YAML files of values (default [])
-  -v, --verbose             show the computed YAML values as well.
+  -x, --execute stringArray   only execute the given templates.
+  -h, --help                  help for template
+      --kube-version string   the Kubernetes version used as Capabilities.KubeVersion.Major/Minor (e.g. v1.7)
+  -n, --namespace string      namespace (default "NAMESPACE")
+      --notes                 show the computed NOTES.txt file as well.
+  -r, --release string        release name (default "RELEASE-NAME")
+      --set stringArray       set values on the command line. See 'helm install -h'
+  -f, --values valueFiles     specify one or more YAML files of values (default [])
+  -v, --verbose               show the computed YAML values as well.
 ```
 
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0b1e82c6e57deeeb877eee55cd3def35a5d95a89b410873960e53483b49b8922
-updated: 2017-07-31T09:30:02.493522293-06:00
+hash: 6c1060a8617df58f714905a19d01e59dc5ba902c345e0e9b5624f3f317bc7bca
+updated: 2017-08-28T13:29:43.245005+09:00
 imports:
 - name: github.com/aokoli/goutils
   version: 9c37978a95bd5c709a15883b6242714ea6709e64
@@ -32,7 +32,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/Masterminds/semver
-  version: 3f0ab6d4ab4bed1c61caf056b63a6e62190c7801
+  version: 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd
 - name: github.com/Masterminds/sprig
   version: 9526be0327b26ad31aa70296a7b10704883976d5
 - name: github.com/satori/go.uuid
@@ -53,7 +53,7 @@ imports:
   subpackages:
   - pkg/version
 - name: k8s.io/helm
-  version: 7cf31e8d9a026287041bae077b09165be247ae66
+  version: 5bc7c619f85d74702e810a8325e0a24f729aa11a
   subpackages:
   - pkg/chartutil
   - pkg/engine

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,3 +7,5 @@ import:
   - pkg/chartutil
   - pkg/engine
 - package: github.com/ghodss/yaml
+- package: github.com/Masterminds/semver
+  version: ^1.3.1


### PR DESCRIPTION
This PR adds `--kube-version` flag. It allows you to specify the Kubernetes version used as `Capabilities.KubeVersion.Major/Minor`.

- `--kube-version`: the Kubernetes version used as Capabilities.KubeVersion.Major/Minor (e.g. v1.7)

```console
$ helm template stable/prometheus --kube-version=v1.7
```